### PR TITLE
fix: correct registry selection mapping and remove VCS metadata from …

### DIFF
--- a/.changeset/light-donkeys-judge.md
+++ b/.changeset/light-donkeys-judge.md
@@ -1,0 +1,7 @@
+---
+'start-ts-by': patch
+---
+
+Fixed a registry selection bug in [`runActionPromptArgTemplateFlag`](src/commands/createAction/runActionPromptArgTemplateFlag.ts:1) by using the selected item index (instead of `type`) to identify the chosen registry. This resolves incorrect selection behavior when multiple registries are available.
+
+Fixed local template import cleanup in [`templateToLocal`](src/utils/templateToLocal.ts:1) by adding `removeVcsMetadata()` to remove VCS metadata directories such as `.git`, `.hg`, and `.svn`. Added tests in [`templateToLocal.test`](src/utils/templateToLocal.test.ts:1) to verify metadata removal behavior.

--- a/registry-config.json
+++ b/registry-config.json
@@ -1,8 +1,13 @@
 {
     "registries": [
         {
-            "name": "start-ts-templates",
-            "url": "https://raw.githubusercontent.com/royfw/start-ts-templates/main/registry.json",
+            "name": "rfjs/templates",
+            "url": "https://raw.githubusercontent.com/royfw/rfjs/main/templates/registry.json",
+            "enabled": true
+        },
+        {
+            "name": "rfjs/templates/monorepo",
+            "url": "https://raw.githubusercontent.com/royfw/rfjs/main/templates/monorepo/registry.json",
             "enabled": true
         }
     ],

--- a/src/commands/createAction/runActionPromptArgTemplateFlag.ts
+++ b/src/commands/createAction/runActionPromptArgTemplateFlag.ts
@@ -17,9 +17,9 @@ export async function runActionPromptArgTemplateFlag(arg?: string) {
 
       // 第一層：選擇來源
       const sourceChoices = [
-        ...sources.map((source) => ({
+        ...sources.map((source, index) => ({
           name: `${source.name} (${source.templates.length} templates)`,
-          value: source.type,
+          value: String(index),
           short: source.name,
         })),
         {
@@ -71,7 +71,8 @@ export async function runActionPromptArgTemplateFlag(arg?: string) {
       }
 
       // 第二層：從選定來源選擇具體 template
-      const selectedSource = sources.find((s) => s.type === sourceResponse.source);
+      const selectedSource = sources[Number(sourceResponse.source)];
+
       if (!selectedSource || selectedSource.templates.length === 0) {
         console.error('❌ No templates available');
         process.exit(1);

--- a/src/utils/templateToLocal.test.ts
+++ b/src/utils/templateToLocal.test.ts
@@ -1,0 +1,70 @@
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+import { afterEach, describe, expect, it } from 'vitest';
+import { templateToLocal } from './templateToLocal';
+
+describe('templateToLocal', () => {
+  const tempRoots: string[] = [];
+
+  const createTempDir = (prefix: string) => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), prefix));
+    tempRoots.push(dir);
+    return dir;
+  };
+
+  afterEach(() => {
+    for (const dir of tempRoots.splice(0)) {
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it('should remove .git metadata when copying from local template', () => {
+    const sourceDir = createTempDir('template-source-');
+    const targetDir = createTempDir('template-target-');
+
+    fs.mkdirSync(path.join(sourceDir, '.git'), { recursive: true });
+    fs.writeFileSync(path.join(sourceDir, '.git', 'HEAD'), 'ref: refs/heads/main\n');
+    fs.writeFileSync(path.join(sourceDir, 'README.md'), '# template\n');
+
+    templateToLocal(
+      {
+        repoUrl: sourceDir,
+        ref: '',
+        subdir: '',
+        isGithub: false,
+        isLocal: true,
+      },
+      targetDir,
+    );
+
+    expect(fs.existsSync(path.join(targetDir, '.git'))).toBe(false);
+    expect(fs.readFileSync(path.join(targetDir, 'README.md'), 'utf-8')).toContain(
+      'template',
+    );
+  });
+
+  it('should remove common VCS metadata folders when copying from local template', () => {
+    const sourceDir = createTempDir('template-source-');
+    const targetDir = createTempDir('template-target-');
+
+    fs.mkdirSync(path.join(sourceDir, '.hg'), { recursive: true });
+    fs.mkdirSync(path.join(sourceDir, '.svn'), { recursive: true });
+    fs.writeFileSync(path.join(sourceDir, 'index.ts'), 'export const ok = true;\n');
+
+    templateToLocal(
+      {
+        repoUrl: sourceDir,
+        ref: '',
+        subdir: '',
+        isGithub: false,
+        isLocal: true,
+      },
+      targetDir,
+    );
+
+    expect(fs.existsSync(path.join(targetDir, '.hg'))).toBe(false);
+    expect(fs.existsSync(path.join(targetDir, '.svn'))).toBe(false);
+    expect(fs.existsSync(path.join(targetDir, 'index.ts'))).toBe(true);
+  });
+});

--- a/src/utils/templateToLocal.ts
+++ b/src/utils/templateToLocal.ts
@@ -3,6 +3,17 @@ import { join } from 'path';
 import { execSync } from 'child_process';
 import { ParsedTemplateType } from '@/types';
 
+const vcsMetaPaths = ['.git', '.hg', '.svn'];
+
+function removeVcsMetadata(targetDir: string) {
+  for (const metaPath of vcsMetaPaths) {
+    const fullPath = join(targetDir, metaPath);
+    if (existsSync(fullPath)) {
+      rmSync(fullPath, { recursive: true, force: true });
+    }
+  }
+}
+
 export function templateToLocal(parsed: ParsedTemplateType, targetDir: string) {
   if (parsed.isLocal) {
     // ==== Local Path ====
@@ -14,6 +25,7 @@ export function templateToLocal(parsed: ParsedTemplateType, targetDir: string) {
     }
     mkdirSync(targetDir, { recursive: true });
     cpSync(fromDir, targetDir, { recursive: true });
+    removeVcsMetadata(targetDir);
     return;
   }
 
@@ -41,7 +53,6 @@ export function templateToLocal(parsed: ParsedTemplateType, targetDir: string) {
   // Clean up temporary directory
   rmSync(tmpDir, { recursive: true, force: true });
 
-  // Remove .git folder from the target
-  const gitDir = join(targetDir, '.git');
-  if (existsSync(gitDir)) rmSync(gitDir, { recursive: true, force: true });
+  // Remove VCS metadata folders from the target
+  removeVcsMetadata(targetDir);
 }


### PR DESCRIPTION
…local templates

Use prompt selection index instead of registry type when resolving selected registry, so template selection works correctly with multiple registries.

Add removeVcsMetadata() to local template import cleanup to remove .git/.hg/.svn directories, and add tests to verify VCS metadata removal behavior.