### PR TITLE
chore(release): sync npm_publish to main after publish

### DIFF
--- a/.changeset/light-donkeys-judge.md
+++ b/.changeset/light-donkeys-judge.md
@@ -1,7 +1,0 @@
----
-'start-ts-by': patch
----
-
-Fixed a registry selection bug in [`runActionPromptArgTemplateFlag`](src/commands/createAction/runActionPromptArgTemplateFlag.ts:1) by using the selected item index (instead of `type`) to identify the chosen registry. This resolves incorrect selection behavior when multiple registries are available.
-
-Fixed local template import cleanup in [`templateToLocal`](src/utils/templateToLocal.ts:1) by adding `removeVcsMetadata()` to remove VCS metadata directories such as `.git`, `.hg`, and `.svn`. Added tests in [`templateToLocal.test`](src/utils/templateToLocal.test.ts:1) to verify metadata removal behavior.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## 0.4.3
+
+### Patch Changes
+
+- 5885731: Fixed a registry selection bug in [`runActionPromptArgTemplateFlag`](src/commands/createAction/runActionPromptArgTemplateFlag.ts:1) by using the selected item index (instead of `type`) to identify the chosen registry. This resolves incorrect selection behavior when multiple registries are available.
+
+  Fixed local template import cleanup in [`templateToLocal`](src/utils/templateToLocal.ts:1) by adding `removeVcsMetadata()` to remove VCS metadata directories such as `.git`, `.hg`, and `.svn`. Added tests in [`templateToLocal.test`](src/utils/templateToLocal.test.ts:1) to verify metadata removal behavior.
+
 ## 0.4.2
 
 ### Patch Changes

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "start-ts-by",
-  "version": "0.4.2",
+  "version": "0.4.3",
   "description": "Start TypeScript project by git repo or local folder templates",
   "main": "src/index.ts",
   "bin": {


### PR DESCRIPTION
This automated PR syncs the latest versions and changelogs from **npm_publish** to **main** after a successful NPM publish.